### PR TITLE
Made it possible for inbound callers to dial channels

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,3 +4,5 @@ Co-op implementation of SLA in ARI using Node.js
 This implementation assumes that you have at least Asterisk 12.0.0 running. This is the version where ARI first came around, and it should have all of the functions required for this project.
 
 You must also have a valid ARI user in ari.conf named "user" and have a password "pass", as well as have 127.0.0.1 (or localhost) and 8088 configured as the bindaddr and bindport respectively in http.conf
+
+You must also have a dialplan extension in extensions.conf that leads to the application (must have same name as what application is being started in the code) and that has an argument to represent the SLA bridge to reach.

--- a/README.md
+++ b/README.md
@@ -5,4 +5,10 @@ This implementation assumes that you have at least Asterisk 12.0.0 running. This
 
 You must also have a valid ARI user in ari.conf named "user" and have a password "pass", as well as have 127.0.0.1 (or localhost) and 8088 configured as the bindaddr and bindport respectively in http.conf
 
-You must also have a dialplan extension in extensions.conf that leads to the application (must have same name as what application is being started in the code) and that has an argument to represent the SLA bridge to reach.
+You must also have a dialplan extension in extensions.conf that leads to the application (must have same name as what application is being started in the code) and that has an argument to represent the SLA bridge to reach.  An example is below:
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+exten => 99,1,NoOp()                                                             
+    same => n,Stasis(sla,999)                                                    
+    same => n,Hangup()
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/app.js
+++ b/app.js
@@ -12,6 +12,10 @@ connect('http://127.0.0.1:8088', 'user', 'pass')
   .catch(errHandler)
   .done();
 
+/**
+ * Checks if the argument tied to the StasisStart event is dialed (not inbound)
+ * @param {String} argument - The argument (either an extension # or dialed)
+ */
 function isDialed(argument) {
   if(argument === 'dialed') {
     return true;

--- a/app.js
+++ b/app.js
@@ -1,4 +1,3 @@
-/*jslint node: true */  
 'use strict';
 
 var ari = require('ari-client');
@@ -14,26 +13,21 @@ connect('http://127.0.0.1:8088', 'user', 'pass')
   .done();
 
 /**
- * Starts Stasis app 'sla' and initiates SLA application after ARI connection.
+ * Waits for a StasisStart event before going into the main SLA module
  * @param {Object} client - Object that contains information from the ARI 
  *   connection.
  */
 function clientLoaded (client) {
   client.start('sla');
-  var defer = Q.defer();
   client.on('StasisStart', function(event, channel) {
-    stasisStart(event, client, channel);
+    if(event.args[0] !== 'dialed') {
+      var bridgeName = event.args[0];
+      sla(client, channel, bridgeName)
+        .then(console.log)
+        .catch(errHandler)
+        .done();
+    }
   });
-}
-
-function stasisStart (event, client, channel) {
-  if(event.args[0] !== 'dialed') {
-    var bridgeNumber = event.args[0];
-    sla(client, channel, bridgeNumber)
-      .then(console.log)
-      .catch(errHandler)
-      .done();
-  }
 }
 
 /**

--- a/app.js
+++ b/app.js
@@ -17,11 +17,7 @@ connect('http://127.0.0.1:8088', 'user', 'pass')
  * @param {String} argument - The argument (either an extension # or dialed)
  */
 function isDialed(argument) {
-  if(argument === 'dialed') {
-    return true;
-  } else {
-    return false;
-  }
+  return argument === 'dialed';
 }
 
 /**

--- a/app.js
+++ b/app.js
@@ -20,10 +20,20 @@ connect('http://127.0.0.1:8088', 'user', 'pass')
  */
 function clientLoaded (client) {
   client.start('sla');
-  sla(client)
-    .then(console.log)
-    .catch(errHandler)
-    .done();
+  var defer = Q.defer();
+  client.on('StasisStart', function(event, channel) {
+    stasisStart(event, client, channel);
+  });
+}
+
+function stasisStart (event, client, channel) {
+  if(event.args[0] !== 'dialed') {
+    var bridgeNumber = event.args[0];
+    sla(client, channel, bridgeNumber)
+      .then(console.log)
+      .catch(errHandler)
+      .done();
+  }
 }
 
 /**
@@ -31,6 +41,5 @@ function clientLoaded (client) {
  * @param {Object} err - error from application.
  */
 function errHandler(err) {
-  console.error(err);
   throw err;
 }

--- a/app.js
+++ b/app.js
@@ -12,6 +12,14 @@ connect('http://127.0.0.1:8088', 'user', 'pass')
   .catch(errHandler)
   .done();
 
+function isDialed(argument) {
+  if(argument === 'dialed') {
+    return true;
+  } else {
+    return false;
+  }
+}
+
 /**
  * Waits for a StasisStart event before going into the main SLA module
  * @param {Object} client - Object that contains information from the ARI 
@@ -20,7 +28,7 @@ connect('http://127.0.0.1:8088', 'user', 'pass')
 function clientLoaded (client) {
   client.start('sla');
   client.on('StasisStart', function(event, channel) {
-    if(event.args[0] !== 'dialed') {
+    if(!isDialed(event.args[0])) {
       var bridgeName = event.args[0];
       sla(client, channel, bridgeName)
         .then(console.log)
@@ -35,5 +43,9 @@ function clientLoaded (client) {
  * @param {Object} err - error from application.
  */
 function errHandler(err) {
-  throw err;
+  if(err.name === 'EarlyHangup' || err.name === 'HangupFailure') {
+   console.log(err.message);
+  } else {
+   throw err;
+  } 
 }

--- a/lib/sla.js
+++ b/lib/sla.js
@@ -15,7 +15,7 @@ function designateMixingBridge(client, bridgeName) {
       function(bridges) {
         var bridge = bridges.filter(function(candidate) {
           return (candidate['bridge_type'] === 'mixing' &&
-            candidate['name'] === bridgeName);
+            candidate.name === bridgeName);
         })[0];
         if (bridge) {
           console.log('Using existing mixing bridge %s numbered %s', 
@@ -126,7 +126,8 @@ function originateChannel(client, inbound, bridge) {
   return defer.promise;
 }
 
-/** Simple utility function for checking if the bridgeName is numerical
+/** 
+ * Simple utility function for checking if the bridgeName is numerical
  * @param {String} bridgeName - the name of the bridge to be created/used
  * @return {boolean} whether or not the bridgeName is numerical
  */
@@ -138,7 +139,8 @@ function checkIfNum (string) {
     return false;
   }
 }
-/** Represents an error that has both a name and message.
+/** 
+ * Represents an error that has both a name and message.
  * @param {String} name - the name/type of the error
  * @param {String} message - the corresponding message
  * Mainly used to avoid crashing the program, as it does with regular errors.
@@ -151,6 +153,8 @@ function CustomError(name, message) {
 /**
  * Receives initial input and begins the application.
  * @param {Object} client - Client received from app.js.
+ * @param {Object} inbound - the inbound channel
+ * @param {String} bridgeName - the name of the bridge to be used/created
  * @return {Q} Q promise object.
  */
 module.exports = function(client, inbound, bridgeName) {
@@ -170,7 +174,7 @@ module.exports = function(client, inbound, bridgeName) {
             else {
               var hangup = Q.denodeify(inbound.hangup.bind(inbound));
               hangup();
-              throw new CustomError('EarlyHangup', 
+              throw new CustomError('EarlyHangup',
                 dialed);
             }
           });

--- a/lib/sla.js
+++ b/lib/sla.js
@@ -98,7 +98,7 @@ function originateChannel(client, inbound, bridge) {
   var defer = Q.defer();
   var dialed = client.Channel();
   var originate = Q.denodeify(dialed.originate.bind(dialed));
-  originate({endpoint: 'SIP/100@tcambron', app: 'sla', appArgs: 'dialed'})
+  originate({endpoint: 'SIP/phone', app: 'sla', appArgs: 'dialed'})
     .catch(function (err) {
       defer.reject(err);
       
@@ -142,22 +142,21 @@ module.exports = function(client, inbound, bridgeName) {
   if(checkIfNum(bridgeName)) {
     var answer = Q.denodeify(inbound.answer.bind(inbound));
     return answer()
-    .then(function() {
-      return designateMixingBridge(client, bridgeName)
-        .then(function (bridge) {
-          return originateChannel(client, inbound, bridge)
-            .then(function (dialed) {
-              if (dialed) {
-                return addChannelsToBridge(inbound, dialed, bridge);
-              }
-              else {
-                var hangup = Q.denodeify(inbound.hangup.bind(inbound));
-                hangup();
-                return 'Channel rejected or caller hung up';
-              }
-            });
-        });
-    });
+      .then(function() {
+        return designateMixingBridge(client, bridgeName);
+      }).then(function (bridge) {
+        return originateChannel(client, inbound, bridge)
+          .then(function (dialed) {
+            if (dialed) {
+              return addChannelsToBridge(inbound, dialed, bridge);
+            }
+            else {
+              var hangup = Q.denodeify(inbound.hangup.bind(inbound));
+              hangup();
+              return 'Channel rejected or caller hung up';
+            }
+          });
+      });
   }
   else {
     var hangup = Q.denodeify(inbound.hangup.bind(inbound));

--- a/lib/sla.js
+++ b/lib/sla.js
@@ -7,14 +7,14 @@ var Q = require('q');
  *   connection.
  * @return {Q} Q promise object.
  */
-function designateMixingBridge(client, bridgeNum) {
+function designateMixingBridge(client, bridgeName) {
   var defer = Q.defer();
   var list = Q.denodeify(client.bridges.list.bind(client));
   list().then(
       function(bridges) {
         var bridge = bridges.filter(function(candidate) {
           return (candidate['bridge_type'] === 'mixing' &&
-            candidate['name'] === bridgeNum);
+            candidate['name'] === bridgeName);
         })[0];
         if (bridge) {
           console.log('Using existing mixing bridge %s numbered %s', 
@@ -22,7 +22,7 @@ function designateMixingBridge(client, bridgeNum) {
           defer.resolve(bridge);
         } else {
           var create = Q.denodeify(client.bridges.create.bind(client));
-          create({type: 'mixing', name: bridgeNum})
+          create({type: 'mixing', name: bridgeName})
             .then(function(bridge) {
               console.log('Created new mixing bridge %s numbered %s',
                 bridge.id, bridge.name);
@@ -37,9 +37,10 @@ function designateMixingBridge(client, bridgeNum) {
 }
 
 /**
- * Adds created channel to the bridge.
- * @param {Object} channel - Created channel to be added to the bridge.
- * @param {Object} bridge - Bridge that channel is to be added to.
+ * Adds inbound and originated channels to the bridge.
+ * @param {Object} inbound - Incoming channel to be added to the bridge.
+ * @param {Object} dialed - Created/dialed channel to be added as well
+ * @param {Object} bridge - Bridge that channels are to be added to.
  * @return {Q} Q promise object.
  */
 function addChannelsToBridge(inbound, dialed, bridge) {
@@ -84,14 +85,15 @@ function addChannelsToBridge(inbound, dialed, bridge) {
 }
 
 /**
- * Creates a channel to a specified endpoint and places it in the Stasis app.
+ * Originates a channel to a specified endpoint and places it in the Stasis app.
  * @param {Object} client - Object that contains information from the ARI
  *   connection.
+ * @param {Object} inbound- the inbound channel
  * @param {Object} bridge - Object that defines the bridge to be passed to
  *   addChannelsToBridge().
  * @return {Q} Q promise object.
  */
-function createChannel(client, inbound, bridge) {
+function originateChannel(client, inbound, bridge) {
   var defer = Q.defer();
   var dialed = client.Channel();
   var originate = Q.denodeify(dialed.originate.bind(dialed));
@@ -99,15 +101,15 @@ function createChannel(client, inbound, bridge) {
     .catch(function (err) {
       defer.reject(err);
     });
-  dialed.on('StasisStart', function(event, dialed) {
+  dialed.once('StasisStart', function(event, dialed) {
     var answer = Q.denodeify(dialed.answer.bind(dialed));
     answer();
     defer.resolve(dialed);
   });
-  dialed.on('ChannelDestroyed', function(event, dialed) {
+  dialed.once('ChannelDestroyed', function(event, dialed) {
     defer.resolve(null);
   });
-  inbound.on('ChannelHangupRequest', function(event, inbound) {
+  inbound.once('ChannelHangupRequest', function(event, inbound) {
     defer.resolve(null);
     var hangup = Q.denodeify(dialed.hangup.bind(dialed));
     hangup()
@@ -118,43 +120,56 @@ function createChannel(client, inbound, bridge) {
   return defer.promise;
 }
 
+/** Simple utility function for checking if the bridgeName is numerical
+ * @param {String} bridgeName - the name of the bridge to be created/used
+ */
+function checkIfNum (bridgeName) {
+  if(!isNaN(parseInt(bridgeName))) {
+    return true;
+  }
+  else {
+    return false;
+  }
+}
+
 /**
  * Receives initial input and begins the application.
  * @param {Object} client - Client received from app.js.
  * @return {Q} Q promise object.
  */
-module.exports = function(client, channel, bridgeNumber) {
+module.exports = function(client, inbound, bridgeName) {
   //This specifies what bridge number to use for SLA
-  if(!isNaN(parseInt(bridgeNumber))) {
-    var answer = Q.denodeify(channel.answer.bind(channel));
-    answer();
-    return designateMixingBridge(client, bridgeNumber)
-      .then(function (bridge) {
-        return createChannel(client, channel, bridge)
-          .then(function (dialed) {
-            if (dialed) {
-              return addChannelsToBridge(channel, dialed, bridge);
-            }
-            else {
-              var hangup = Q.denodeify(channel.hangup.bind(channel));
-              hangup(function(channel) {
-                 console.log('Hanging up inbound channel %s', channel.id);
+  var defer = Q.defer();
+  var numerical = checkIfNum(bridgeName);
+  if(numerical) {
+    var answer = Q.denodeify(inbound.answer.bind(inbound));
+    return answer()
+      .then(function() {
+        return designateMixingBridge(client, bridgeName)
+          .then(function (bridge) {
+            return originateChannel(client, inbound, bridge)
+              .then(function (dialed) {
+                if (dialed) {
+                  return addChannelsToBridge(inbound, dialed, bridge);
+                }
+                else {
+                  var hangup = Q.denodeify(inbound.hangup.bind(inbound));
+                  hangup(function(inbound) {
+                     console.log('Hanging up inbound channel %s', inbound.id);
+                  });
+                  var defer = Q.defer();
+                  return 'Channel rejected or caller hung up';
+                }
               });
-              var defer = Q.defer();
-              defer.resolve('Channel rejected or caller hung up');
-              return defer.promise;
-            }
           });
       });
   }
   else {
-    var defer = Q.defer();
-    var hangup = Q.denodeify(channel.hangup.bind(channel));
+    var hangup = Q.denodeify(inbound.hangup.bind(inbound));
     hangup()
       .catch(function (err) {
         defer.reject(err);
       });
-    defer.resolve('Not a numeric SLA specification: ' +  bridgeNumber);
-    return defer.promise;
+    return new Q('Not a numeric SLA specifcation: ' + bridgeName);
   }
 };

--- a/lib/sla.js
+++ b/lib/sla.js
@@ -5,6 +5,7 @@ var Q = require('q');
  * Looks for an existing mixing bridge and creates one if none exist.
  * @param {Object} client - Object that contains information from the ARI
  *   connection.
+ * @param {String} bridgeName - the name of the bridge to be created/designated
  * @return {Q} Q promise object.
  */
 function designateMixingBridge(client, bridgeName) {
@@ -97,9 +98,10 @@ function originateChannel(client, inbound, bridge) {
   var defer = Q.defer();
   var dialed = client.Channel();
   var originate = Q.denodeify(dialed.originate.bind(dialed));
-  originate({endpoint: 'SIP/phone', app: 'sla', appArgs: 'dialed'})
+  originate({endpoint: 'SIP/100@tcambron', app: 'sla', appArgs: 'dialed'})
     .catch(function (err) {
       defer.reject(err);
+      
     });
   dialed.once('StasisStart', function(event, dialed) {
     var answer = Q.denodeify(dialed.answer.bind(dialed));
@@ -110,21 +112,19 @@ function originateChannel(client, inbound, bridge) {
     defer.resolve(null);
   });
   inbound.once('ChannelHangupRequest', function(event, inbound) {
-    defer.resolve(null);
     var hangup = Q.denodeify(dialed.hangup.bind(dialed));
-    hangup()
-      .catch(function (err) {
-        defer.reject(err);
-      });
+    hangup();
+    defer.resolve(null);
   });
   return defer.promise;
 }
 
 /** Simple utility function for checking if the bridgeName is numerical
  * @param {String} bridgeName - the name of the bridge to be created/used
+ * @return {boolean} whether or not the bridgeName is numerical
  */
-function checkIfNum (bridgeName) {
-  if(!isNaN(parseInt(bridgeName))) {
+function checkIfNum (string) {
+  if(!isNaN(parseInt(string))) {
     return true;
   }
   else {
@@ -139,37 +139,29 @@ function checkIfNum (bridgeName) {
  */
 module.exports = function(client, inbound, bridgeName) {
   //This specifies what bridge number to use for SLA
-  var defer = Q.defer();
-  var numerical = checkIfNum(bridgeName);
-  if(numerical) {
+  if(checkIfNum(bridgeName)) {
     var answer = Q.denodeify(inbound.answer.bind(inbound));
     return answer()
-      .then(function() {
-        return designateMixingBridge(client, bridgeName)
-          .then(function (bridge) {
-            return originateChannel(client, inbound, bridge)
-              .then(function (dialed) {
-                if (dialed) {
-                  return addChannelsToBridge(inbound, dialed, bridge);
-                }
-                else {
-                  var hangup = Q.denodeify(inbound.hangup.bind(inbound));
-                  hangup(function(inbound) {
-                     console.log('Hanging up inbound channel %s', inbound.id);
-                  });
-                  var defer = Q.defer();
-                  return 'Channel rejected or caller hung up';
-                }
-              });
-          });
-      });
+    .then(function() {
+      return designateMixingBridge(client, bridgeName)
+        .then(function (bridge) {
+          return originateChannel(client, inbound, bridge)
+            .then(function (dialed) {
+              if (dialed) {
+                return addChannelsToBridge(inbound, dialed, bridge);
+              }
+              else {
+                var hangup = Q.denodeify(inbound.hangup.bind(inbound));
+                hangup();
+                return 'Channel rejected or caller hung up';
+              }
+            });
+        });
+    });
   }
   else {
     var hangup = Q.denodeify(inbound.hangup.bind(inbound));
-    hangup()
-      .catch(function (err) {
-        defer.reject(err);
-      });
-    return new Q('Not a numeric SLA specifcation: ' + bridgeName);
+    hangup();
+    return Q.reject(new Error('Not a numeric SLA specifcation: ' + bridgeName));
   }
 };

--- a/lib/sla.js
+++ b/lib/sla.js
@@ -7,22 +7,25 @@ var Q = require('q');
  *   connection.
  * @return {Q} Q promise object.
  */
-function designateMixingBridge(client) {
+function designateMixingBridge(client, bridgeNum) {
   var defer = Q.defer();
   var list = Q.denodeify(client.bridges.list.bind(client));
   list().then(
       function(bridges) {
         var bridge = bridges.filter(function(candidate) {
-          return candidate['bridge_type'] === 'mixing';
+          return (candidate['bridge_type'] === 'mixing' &&
+            candidate['name'] === bridgeNum);
         })[0];
         if (bridge) {
-          console.log('Using existing mixing bridge %s', bridge.id);
+          console.log('Using existing mixing bridge %s numbered %s', 
+            bridge.id, bridge.name);
           defer.resolve(bridge);
         } else {
           var create = Q.denodeify(client.bridges.create.bind(client));
-          create({type: 'mixing'})
+          create({type: 'mixing', name: bridgeNum})
             .then(function(bridge) {
-              console.log('Created new mixing bridge %s', bridge.id);
+              console.log('Created new mixing bridge %s numbered %s',
+                bridge.id, bridge.name);
               defer.resolve(bridge);
             });
         }
@@ -39,20 +42,43 @@ function designateMixingBridge(client) {
  * @param {Object} bridge - Bridge that channel is to be added to.
  * @return {Q} Q promise object.
  */
-function addChannelsToBridge(channel, bridge) {
+function addChannelsToBridge(inbound, dialed, bridge) {
   var defer = Q.defer();
-  console.log('Adding channel to bridge %s', bridge.id);
+  var numInBridge = 0;
+  console.log('Adding channels to bridge %s', bridge.id);
   var addChannel = Q.denodeify(bridge.addChannel.bind(bridge));
-  addChannel({channel: channel.id})
+  addChannel({channel: [inbound.id, dialed.id]})
     .catch(function (err) {
       defer.reject(err);
     });
-  bridge.once('ChannelEnteredBridge', function(event, bridge) {
+  bridge.on('ChannelEnteredBridge', function(event, bridge) {
     console.log('Channel %s has entered the bridge', bridge.channel.id);
+    numInBridge += 1;
   });
-  bridge.once('ChannelLeftBridge', function(event, bridge) {
+  bridge.on('ChannelLeftBridge', function(event, bridge) {
+    numInBridge -= 1;
     console.log('Channel %s has left the bridge', bridge.channel.id);
-    defer.resolve('Application completed');
+    if(numInBridge === 1) {
+      if(bridge.channel.id === inbound.id) {
+        console.log('Hanging up dialed channel %s', dialed.id);
+        var hangupDialed = Q.denodeify(dialed.hangup.bind(dialed));
+        hangupDialed()
+          .catch(function (err) {
+            defer.reject(err);
+          });
+      }
+      else if(bridge.channel.id === dialed.id) {
+        console.log('Hanging up inbound channel %s', inbound.id);
+        var hangupInbound = Q.denodeify(inbound.hangup.bind(inbound));
+        hangupInbound()
+          .catch(function (err) {
+            defer.reject(err);
+          });
+      }
+    }
+    if(numInBridge === 0) {
+      defer.resolve('Application completed');
+    }
   });
   return defer.promise;
 }
@@ -65,16 +91,29 @@ function addChannelsToBridge(channel, bridge) {
  *   addChannelsToBridge().
  * @return {Q} Q promise object.
  */
-function createChannel(client, bridge) {
+function createChannel(client, inbound, bridge) {
   var defer = Q.defer();
-  var channel = client.Channel();
-  var originate = Q.denodeify(channel.originate.bind(channel));
-  originate({endpoint: 'SIP/phone', app: 'sla'})
+  var dialed = client.Channel();
+  var originate = Q.denodeify(dialed.originate.bind(dialed));
+  originate({endpoint: 'SIP/phone', app: 'sla', appArgs: 'dialed'})
     .catch(function (err) {
       defer.reject(err);
     });
-  channel.once('StasisStart', function(event, channel) {
-    defer.resolve(channel);
+  dialed.on('StasisStart', function(event, dialed) {
+    var answer = Q.denodeify(dialed.answer.bind(dialed));
+    answer();
+    defer.resolve(dialed);
+  });
+  dialed.on('ChannelDestroyed', function(event, dialed) {
+    defer.resolve(null);
+  });
+  inbound.on('ChannelHangupRequest', function(event, inbound) {
+    defer.resolve(null);
+    var hangup = Q.denodeify(dialed.hangup.bind(dialed));
+    hangup()
+      .catch(function (err) {
+        defer.reject(err);
+      });
   });
   return defer.promise;
 }
@@ -84,12 +123,38 @@ function createChannel(client, bridge) {
  * @param {Object} client - Client received from app.js.
  * @return {Q} Q promise object.
  */
-module.exports = function(client) {
-  return designateMixingBridge(client)
-    .then(function (bridge) {
-      return createChannel(client, bridge)
-        .then(function (channel) {
-          return addChannelsToBridge(channel, bridge);
-        });
-    });
+module.exports = function(client, channel, bridgeNumber) {
+  //This specifies what bridge number to use for SLA
+  if(!isNaN(parseInt(bridgeNumber))) {
+    var answer = Q.denodeify(channel.answer.bind(channel));
+    answer();
+    return designateMixingBridge(client, bridgeNumber)
+      .then(function (bridge) {
+        return createChannel(client, channel, bridge)
+          .then(function (dialed) {
+            if (dialed) {
+              return addChannelsToBridge(channel, dialed, bridge);
+            }
+            else {
+              var hangup = Q.denodeify(channel.hangup.bind(channel));
+              hangup(function(channel) {
+                 console.log('Hanging up inbound channel %s', channel.id);
+              });
+              var defer = Q.defer();
+              defer.resolve('Channel rejected or caller hung up');
+              return defer.promise;
+            }
+          });
+      });
+  }
+  else {
+    var defer = Q.defer();
+    var hangup = Q.denodeify(channel.hangup.bind(channel));
+    hangup()
+      .catch(function (err) {
+        defer.reject(err);
+      });
+    defer.resolve('Not a numeric SLA specification: ' +  bridgeNumber);
+    return defer.promise;
+  }
 };

--- a/lib/sla.js
+++ b/lib/sla.js
@@ -53,15 +53,16 @@ function addChannelsToBridge(inbound, dialed, bridge) {
     .catch(function (err) {
       defer.reject(err);
     });
-  bridge.on('ChannelEnteredBridge', function(event, bridge) {
-    console.log('Channel %s has entered the bridge', bridge.channel.id);
+  function channelEntered(event, object) {
+    console.log('Channel %s has entered the bridge', object.channel.id);
     numInBridge += 1;
-  });
-  bridge.on('ChannelLeftBridge', function(event, bridge) {
+  }
+  bridge.on('ChannelEnteredBridge', channelEntered);
+  function channelLeft(event, object) {
     numInBridge -= 1;
-    console.log('Channel %s has left the bridge', bridge.channel.id);
+    console.log('Channel %s has left the bridge', object.channel.id);
     if(numInBridge === 1) {
-      if(bridge.channel.id === inbound.id) {
+      if(object.channel.id === inbound.id) {
         console.log('Hanging up dialed channel %s', dialed.id);
         var hangupDialed = Q.denodeify(dialed.hangup.bind(dialed));
         hangupDialed()
@@ -69,7 +70,7 @@ function addChannelsToBridge(inbound, dialed, bridge) {
             defer.reject(err);
           });
       }
-      else if(bridge.channel.id === dialed.id) {
+      else if(object.channel.id === dialed.id) {
         console.log('Hanging up inbound channel %s', inbound.id);
         var hangupInbound = Q.denodeify(inbound.hangup.bind(inbound));
         hangupInbound()
@@ -80,8 +81,11 @@ function addChannelsToBridge(inbound, dialed, bridge) {
     }
     if(numInBridge === 0) {
       defer.resolve('Application completed');
+      object.bridge.removeListener('ChannelEnteredBridge', channelEntered);
+      object.bridge.removeListener('ChannelLeftBridge', channelLeft);
     }
-  });
+  };
+  bridge.on('ChannelLeftBridge', channelLeft);
   return defer.promise;
 }
 
@@ -98,7 +102,7 @@ function originateChannel(client, inbound, bridge) {
   var defer = Q.defer();
   var dialed = client.Channel();
   var originate = Q.denodeify(dialed.originate.bind(dialed));
-  originate({endpoint: 'SIP/phone', app: 'sla', appArgs: 'dialed'})
+  originate({endpoint: 'SIP/100@tcambron', app: 'sla', appArgs: 'dialed'})
     .catch(function (err) {
       defer.reject(err);
       

--- a/lib/sla.js
+++ b/lib/sla.js
@@ -67,6 +67,7 @@ function addChannelsToBridge(inbound, dialed, bridge) {
         var hangupDialed = Q.denodeify(dialed.hangup.bind(dialed));
         hangupDialed()
           .catch(function (err) {
+            err.name = 'HangupFailure';
             defer.reject(err);
           });
       }
@@ -75,6 +76,7 @@ function addChannelsToBridge(inbound, dialed, bridge) {
         var hangupInbound = Q.denodeify(inbound.hangup.bind(inbound));
         hangupInbound()
           .catch(function (err) {
+            err.name = 'HangupFailure';
             defer.reject(err);
           });
       }
@@ -84,7 +86,7 @@ function addChannelsToBridge(inbound, dialed, bridge) {
       object.bridge.removeListener('ChannelEnteredBridge', channelEntered);
       object.bridge.removeListener('ChannelLeftBridge', channelLeft);
     }
-  };
+  }
   bridge.on('ChannelLeftBridge', channelLeft);
   return defer.promise;
 }
@@ -102,8 +104,9 @@ function originateChannel(client, inbound, bridge) {
   var defer = Q.defer();
   var dialed = client.Channel();
   var originate = Q.denodeify(dialed.originate.bind(dialed));
-  originate({endpoint: 'SIP/100@tcambron', app: 'sla', appArgs: 'dialed'})
+  originate({endpoint: 'SIP/phone', app: 'sla', appArgs: 'dialed'})
     .catch(function (err) {
+      err.name = 'originateFailure';
       defer.reject(err);
       
     });
@@ -113,12 +116,12 @@ function originateChannel(client, inbound, bridge) {
     defer.resolve(dialed);
   });
   dialed.once('ChannelDestroyed', function(event, dialed) {
-    defer.resolve(null);
+    defer.resolve('Dialed channel hungup');
   });
   inbound.once('ChannelHangupRequest', function(event, inbound) {
     var hangup = Q.denodeify(dialed.hangup.bind(dialed));
     hangup();
-    defer.resolve(null);
+    defer.resolve('Inbound channel hungup');
   });
   return defer.promise;
 }
@@ -134,6 +137,15 @@ function checkIfNum (string) {
   else {
     return false;
   }
+}
+/** Represents an error that has both a name and message.
+ * @param {String} name - the name/type of the error
+ * @param {String} message - the corresponding message
+ * Mainly used to avoid crashing the program, as it does with regular errors.
+ */
+function CustomError(name, message) {
+  this.name = name;
+  this.message = message;
 }
 
 /**
@@ -151,13 +163,15 @@ module.exports = function(client, inbound, bridgeName) {
       }).then(function (bridge) {
         return originateChannel(client, inbound, bridge)
           .then(function (dialed) {
-            if (dialed) {
+            // If dialed is an actual channel, it will not be a string
+            if (typeof dialed !== 'string') {
               return addChannelsToBridge(inbound, dialed, bridge);
             }
             else {
               var hangup = Q.denodeify(inbound.hangup.bind(inbound));
               hangup();
-              return 'Channel rejected or caller hung up';
+              throw new CustomError('EarlyHangup', 
+                dialed);
             }
           });
       });
@@ -165,6 +179,7 @@ module.exports = function(client, inbound, bridgeName) {
   else {
     var hangup = Q.denodeify(inbound.hangup.bind(inbound));
     hangup();
-    return Q.reject(new Error('Not a numeric SLA specifcation: ' + bridgeName));
+    return Q.reject(new CustomError('SLASpecficationError',
+          'Not a numeric SLA specification: ' + bridgeName));
   }
 };


### PR DESCRIPTION
If the SLA bridge (specified in the dialplan) is numeric,
then create or use a preexisting bridge that has the same
name as the value specified in the dialplan, create a new channel
to dial a specified endpoint.  If the endpoint hangs up, hang up
inbound caller. If the inbound caller hangs up, hang up dialed end.
Application resets when all have hung up.
