### PR TITLE
Squashed commit of MultipleParties branch

### DIFF
--- a/lib/sla.js
+++ b/lib/sla.js
@@ -102,26 +102,45 @@ function addChannelsToBridge(inbound, dialed, bridge) {
  */
 function originateChannel(client, inbound, bridge) {
   var defer = Q.defer();
-  var dialed = client.Channel();
-  var originate = Q.denodeify(dialed.originate.bind(dialed));
-  originate({endpoint: 'SIP/phone', app: 'sla', appArgs: 'dialed'})
-    .catch(function (err) {
-      err.name = 'originateFailure';
-      defer.reject(err);
-      
+  var dialed = [client.Channel(), client.Channel()];
+  var originate = [];
+  var numToHangup = dialed.length;
+  var station = ['SIP/phone1', 'SIP/phone2'];
+  dialed.forEach(function (channel, index, dialed) {
+    originate.push(Q.denodeify(dialed[index].originate.bind(dialed[index])));
+    originate[index]({endpoint: station[index], app: 'sla', appArgs: 'dialed',
+        timeout: 30})
+      .catch(function (err) {
+        err.name = 'OriginateFailure';
+        defer.reject(err);
+      });
+    dialed[index].once('StasisStart', function(event, line) {
+      var answer = Q.denodeify(line.answer.bind(line));
+      answer();
+      var toKill = dialed.filter(function (unanswered) {
+        return unanswered.id !== line.id;
+      });
+      toKill.forEach(function (unanswered) {
+        var hangup = Q.denodeify(unanswered.hangup.bind(unanswered));
+        hangup();
+      });
+      defer.resolve(line);
     });
-  dialed.once('StasisStart', function(event, dialed) {
-    var answer = Q.denodeify(dialed.answer.bind(dialed));
-    answer();
-    defer.resolve(dialed);
-  });
-  dialed.once('ChannelDestroyed', function(event, dialed) {
-    defer.resolve('Dialed channel hungup');
-  });
-  inbound.once('ChannelHangupRequest', function(event, inbound) {
-    var hangup = Q.denodeify(dialed.hangup.bind(dialed));
-    hangup();
-    defer.resolve('Inbound channel hungup');
+    inbound.once('ChannelHangupRequest', function(event, line) {
+      defer.resolve('Inbound channel hungup');
+      dialed.forEach(function (unanswered) {
+        var hangup = Q.denodeify(unanswered.hangup.bind(unanswered));
+        hangup();
+      });
+    });
+    dialed[index].once('ChannelDestroyed', function(event) {
+      originate.pop(dialed[index]);
+      if(originate.length === 0) {
+        defer.resolve('All dialed channels hungup');
+        var hangup = Q.denodeify(inbound.hangup.bind(inbound));
+        hangup();
+      }
+    });
   });
   return defer.promise;
 }
@@ -131,7 +150,7 @@ function originateChannel(client, inbound, bridge) {
  * @param {String} bridgeName - the name of the bridge to be created/used
  * @return {boolean} whether or not the bridgeName is numerical
  */
-function checkIfNum (string) {
+function checkIfNum(string) {
   if(!isNaN(parseInt(string))) {
     return true;
   }
@@ -139,6 +158,17 @@ function checkIfNum (string) {
     return false;
   }
 }
+/** 
+ * Represents an error that has both a name and message.
+ * @param {String} name - the name/type of the error
+ * @param {String} message - the corresponding message
+ * Mainly used to avoid crashing the program, as it does with regular errors.
+ */
+function CustomError(name, message) {
+  this.name = name;
+  this.message = message;
+}
+
 /** 
  * Represents an error that has both a name and message.
  * @param {String} name - the name/type of the error


### PR DESCRIPTION
Allows for dialing of multiple parties.

Added code primarily to the originateChannel method to allow for
multiple hardcoded phones to be dialed upon StasisStart. When one
dialed phone answers, the other dialed phones are hung up. If all
dialed phones hangup or do not answer, the inbound channel is hungup.
Added two more tests for functionality.
